### PR TITLE
change to be more accurate for detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,22 @@ module.exports = (url, options) => {
   return got(url, options).then(response => {
 
     let result = jschardet.detect(response.body);
-    let body = iconv.decode(response.body, result.encoding);
+    let body;
+    if (!result || !result.encoding || (result.confidence || 0) < 0.99) {
+      let head = response.body.toString('ascii').match(/<head[\s>]([\s\S]*?)<\/head>/i);
+      if (head) {
+        let charset = head[1].match(/<meta[^>]*[\s;]+charset\s*=\s*["']?([\w\-_]+)["']?/i);
+        if (charset) {
+          body = iconv.decode(response.body, charset[1].trim());
+        } else {
+          body = response.body.toString('utf8');
+        }
+      } else {
+        body = response.body.toString('utf8');
+      }
+    } else {
+      body = iconv.decode(response.body, result.encoding);
+    }
 
     if (!isHTML(body)) {
       return Promise.reject('Response is not HTML');


### PR DESCRIPTION
detection of [jschardet](https://github.com/aadsm/jschardet) is not reliable enough.

e.g.)
[this](https://retrip.jp/articles/31281/) is detected as `ISO-8859-2`, nevertheless it should be detected as `utf8`.

so i added these features below.

- if the result of `jschardet` is not reliable enough(i.e. if confidence is under 0.99), then check the value of `charset` attribute.

- if no suitable charset is found, just use `utf8` instead.

refer to [this](https://github.com/ktty1220/cheerio-httpcli/blob/master/lib/encoding.js).