### PR TITLE
fix for undefined src attribute

### DIFF
--- a/packages/rog-plugin-images/index.js
+++ b/packages/rog-plugin-images/index.js
@@ -11,7 +11,7 @@ module.exports = function($, url) {
       urls.push(src);
     } else if (src && src.startsWith('data:')) {
       urls.push(src);
-    } else {
+    } else if (src) {
       urls.push(URL.resolve(url, src));
     }
   });


### PR DESCRIPTION
some webpage contain `img` tag that has no src attribute.
```
<img alt=""/>
```
e.g. [twitter](https://twitter.com/RADWIMPS_sokuho/status/713189912749584384)

this pull request fixes these case.